### PR TITLE
fix expectedly wrapping arithmetic

### DIFF
--- a/riscv/src/components/clic.rs
+++ b/riscv/src/components/clic.rs
@@ -802,12 +802,29 @@ impl CLIC {
                     }
                     if mmio_entry.clicintie != 1 || mmio_entry.clicintip != 1 {
                         //dequeue self if pending or enabled status is 0
+                        // we could be more clever about checking when this should happen, this should
+                        // only really do something whenever we write to config registers
+                        // or dispatch an interrupt, i.e. the wraps will never happen.
                         if queue
-                            .remove(&(((addr - offset + 4u32 * i as u32 - 0x1000) / 4) - 0x20))
+                            .remove(
+                                &((addr
+                                    .wrapping_sub(offset)
+                                    .wrapping_add(4u32)
+                                    .wrapping_mul(i as u32)
+                                    .wrapping_sub(0x1000))
+                                    / 4)
+                                .wrapping_sub(0x20),
+                            )
                             .is_some()
                         {
                             history_entry.queue_op.push((
-                                ((addr - offset + 4u32 * i as u32 - 0x1000) / 4),
+                                (addr
+                                    .wrapping_sub(offset)
+                                    .wrapping_add(4u32)
+                                    .wrapping_mul(i as u32)
+                                    .wrapping_sub(0x1000)
+                                    / 4)
+                                .wrapping_sub(0x20),
                                 mmio_entry.clicintctl,
                                 true,
                             ));


### PR DESCRIPTION
some address arithmetic is expected to allow over/underflow (because in those cases, the results of the operation are actually unused). this explicitly defines those operations as wrapping to prevent UB panics.

additionally, this made me notice the history entry was incorrect for this case was incorrect, so this fixes that.